### PR TITLE
CI doesn't need to run upon pushing to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI-Pipeline
 
 on:
   push:
+    branches-ignore:
+      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
The main branch is protected and only pull requests are allowed. Upon pull requests (and pushes to branches other than main) the CI runs, which is sufficient for the CI.

Closes #18 