### PR TITLE
Add dependency to fix reloading issue on production

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,7 +35,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -51,6 +50,11 @@
             <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
             <version>4.13.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.neuefische.java</groupId>
+            <artifactId>spring-boot-starter-fallback-page</artifactId>
+            <version>1.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Frontend routing requests will be served "correctly" by returning the default starting page.

Closes #23